### PR TITLE
:broom: Replacing github.com/stretchr/testify with gotest.tools/v3

### DIFF
--- a/cmd/kn-event-sender/main_test.go
+++ b/cmd/kn-event-sender/main_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	kes "knative.dev/kn-plugin-event/cmd/kn-event-sender"
 	"knative.dev/kn-plugin-event/pkg/cli/ics"
 	"knative.dev/kn-plugin-event/pkg/tests"
@@ -19,7 +19,7 @@ func TestMainSender(t *testing.T) {
 	want.SetType("example")
 	want.SetSource("tests://example")
 	kevent, err := ics.Encode(want)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 
 	got, err := tests.WithCloudEventsServer(func(serverURL url.URL) error {
 		env := map[string]string{
@@ -31,7 +31,7 @@ func TestMainSender(t *testing.T) {
 			return nil
 		})
 	})
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 
-	assert.EqualValues(t, want, *got)
+	assert.DeepEqual(t, want, *got)
 }

--- a/cmd/kn-event/cmd/root_test.go
+++ b/cmd/kn-event/cmd/root_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/cmd/kn-event/cmd"
 )
 
@@ -20,5 +20,5 @@ func TestRootInvalidCommand(t *testing.T) {
 	c.Out(buf)
 	c.ExecuteOrFail()
 
-	assert.True(t, called)
+	assert.Check(t, called)
 }

--- a/cmd/kn-event/cmd/send_test.go
+++ b/cmd/kn-event/cmd/send_test.go
@@ -3,9 +3,10 @@ package cmd_test
 import (
 	"bytes"
 	"net/url"
+	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/cmd/kn-event/cmd"
 	"knative.dev/kn-plugin-event/pkg/tests"
 )
@@ -27,16 +28,14 @@ func TestSendToAddress(t *testing.T) {
 		tc.Out(buf)
 		return tc.Execute()
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	assert.NilError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "Event (ID: 654321) have been sent.")
-	assert.NotNil(t, ce)
+	assert.Check(t, strings.Contains(out, "Event (ID: 654321) have been sent."))
+	assert.Check(t, ce != nil)
 	assert.Equal(t, "654321", ce.ID())
 	payload, err := tests.UnmarshalCloudEventData(ce.Data())
-	assert.NoError(t, err)
-	assert.EqualValues(t, map[string]interface{}{
+	assert.NilError(t, err)
+	assert.DeepEqual(t, map[string]interface{}{
 		"person": map[string]interface{}{
 			"name":  "Chris",
 			"email": "ksuszyns@example.com",

--- a/cmd/kn-event/cmd/version_test.go
+++ b/cmd/kn-event/cmd/version_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/cmd/kn-event/cmd"
 	"knative.dev/kn-plugin-event/pkg/cli"
 	"knative.dev/kn-plugin-event/pkg/metadata"
@@ -16,7 +16,7 @@ import (
 func TestVersionSubCommandWithHuman(t *testing.T) {
 	versionSubCommandChecks(t, "human", func(in []byte, out interface{}) (err error) {
 		pv, ok := out.(*cli.PluginVersionOutput)
-		assert.True(t, ok)
+		assert.Check(t, ok)
 		str := string(in)
 		r := regexp.MustCompile("([^ ]+) version: (.+)")
 		matches := r.FindStringSubmatch(str)
@@ -42,10 +42,10 @@ func versionSubCommandChecks(t *testing.T, format string, unmarshal unmarshalFun
 	tc.Args("version", "-o", format)
 	buf := bytes.NewBuffer([]byte{})
 	tc.Out(buf)
-	assert.NoError(t, tc.Execute())
+	assert.NilError(t, tc.Execute())
 
 	pv := cli.PluginVersionOutput{}
-	assert.NoError(t, unmarshal(buf.Bytes(), &pv))
+	assert.NilError(t, unmarshal(buf.Bytes(), &pv))
 	assert.Equal(t, metadata.PluginName, pv.Name)
 	assert.Equal(t, metadata.Version, pv.Version)
 }
@@ -56,5 +56,6 @@ func TestPresentAsWithInvalidOutput(t *testing.T) {
 	tc.Out(buf)
 	tc.Args("version", "-o", "invalid")
 	err := tc.Execute()
-	assert.IsType(t, cmd.ErrUnsupportedOutputMode, err)
+	assert.Error(t, err, "invalid argument \"invalid\" for "+
+		"\"-o, --output\" flag: must be 'human', 'json', 'yaml'")
 }

--- a/cmd/kn-event/main_test.go
+++ b/cmd/kn-event/main_test.go
@@ -3,9 +3,10 @@ package main // nolint:testpackage
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/cmd/kn-event/cmd"
 )
 
@@ -23,5 +24,5 @@ func TestMainFunc(t *testing.T) {
 	main()
 
 	out := buf.String()
-	assert.Contains(t, out, "Manage CloudEvents from command line")
+	assert.Check(t, strings.Contains(out, "Manage CloudEvents from command line"))
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/magefile/mage v1.11.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/spf13/cobra v1.2.1
-	github.com/stretchr/testify v1.7.0
 	github.com/thediveo/enumflag v0.10.0
 	github.com/wavesoftware/go-ensure v1.0.0
 	github.com/wavesoftware/go-magetasks v0.6.0

--- a/pkg/cli/create_test.go
+++ b/pkg/cli/create_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/cli"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/tests"
@@ -150,7 +150,7 @@ func TestCreateWithArgs(t *testing.T) {
 	}
 	app := cli.App{}
 	actual, err := app.CreateWithArgs(args)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, eventType, actual.Type())
 	assert.Equal(t, id, actual.ID())
 	assert.Equal(t, eventSource, actual.Source())
@@ -164,10 +164,9 @@ func TestCreateWithArgs(t *testing.T) {
 		"active": true,
 	}
 	actualData, err := tests.UnmarshalCloudEventData(actual.Data())
-	assert.NoError(t, err)
-	assert.EqualValues(t, expectedData, actualData)
-	delta := tests.UnixNanoDelta
-	assert.InDelta(t, time.Now().UnixNano(), actual.Time().UnixNano(), delta)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expectedData, actualData)
+	assert.Check(t, tests.TimesAlmostEqual(time.Now(), actual.Time()))
 }
 
 func exampleEvent(t *testing.T) *cloudevents.Event {
@@ -175,7 +174,7 @@ func exampleEvent(t *testing.T) *cloudevents.Event {
 	e := event.NewDefault()
 	e.SetTime(time.Unix(1598277672, 601161))
 	e.SetID("99e4f4f6-08ff-4bff-acf1-47f61ded68c9")
-	assert.NoError(t, e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
+	assert.NilError(t, e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
 		"person": map[string]interface{}{
 			"name":  "Chris",
 			"email": "ksuszyns@example.org",

--- a/pkg/cli/ics/encoding_test.go
+++ b/pkg/cli/ics/encoding_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/cli/ics"
 )
 
@@ -18,14 +18,14 @@ func TestEncodeDecode(t *testing.T) {
 	err := ce.SetData("application/json", map[string]interface{}{
 		"value": 42,
 	})
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	want := &ce
 
 	repr, err := ics.Encode(ce)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, repr)
+	assert.NilError(t, err)
+	assert.Check(t, repr != "")
 	got, err := ics.Decode(repr)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 
-	assert.EqualValues(t, want, got)
+	assert.DeepEqual(t, want, got)
 }

--- a/pkg/cli/ics/send_test.go
+++ b/pkg/cli/ics/send_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/cli/ics"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/tests"
@@ -18,7 +18,7 @@ func TestSendFromEnv(t *testing.T) {
 	want.SetType("example")
 	want.SetSource("tests://example")
 	kevent, err := ics.Encode(want)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	sender := &tests.Sender{}
 	env := map[string]string{
 		"K_SINK":  "http://cosmos.custer.local",
@@ -30,8 +30,8 @@ func TestSendFromEnv(t *testing.T) {
 		},
 	}}
 	err = tests.WithEnviron(env, app.SendFromEnv)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(sender.Sent))
 	got := sender.Sent[0]
-	assert.EqualValues(t, want, got)
+	assert.DeepEqual(t, want, got)
 }

--- a/pkg/cli/send_test.go
+++ b/pkg/cli/send_test.go
@@ -3,10 +3,11 @@ package cli_test
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/cli"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/tests"
@@ -50,12 +51,12 @@ func assertWithOutputMode(t *testing.T, want cloudevents.Event, mode cli.OutputM
 			OutWriter: &buf,
 		},
 	)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	out := buf.String()
 	assert.Equal(t, 1, len(sender.Sent))
 	assert.Equal(t, want.ID(), sender.Sent[0].ID())
 
-	assert.Contains(t, out,
+	assert.Check(t, strings.Contains(out,
 		fmt.Sprintf("Event (ID: %s) have been sent.", want.ID()),
-	)
+	))
 }

--- a/pkg/event/create_test.go
+++ b/pkg/event/create_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/tests"
 )
@@ -27,7 +27,7 @@ func TestCreateFromSpec(t *testing.T) {
 		},
 	}
 	actual, err := event.CreateFromSpec(spec)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, eventType, actual.Type())
 	assert.Equal(t, id, actual.ID())
 	assert.Equal(t, eventSource, actual.Source())
@@ -41,10 +41,9 @@ func TestCreateFromSpec(t *testing.T) {
 		"active": true,
 	}
 	actualData, err := tests.UnmarshalCloudEventData(actual.Data())
-	assert.NoError(t, err)
-	assert.EqualValues(t, expectedData, actualData)
-	delta := tests.UnixNanoDelta
-	assert.InDelta(t, time.Now().UnixNano(), actual.Time().UnixNano(), delta)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expectedData, actualData)
+	assert.Check(t, tests.TimesAlmostEqual(time.Now(), actual.Time()))
 }
 
 func TestCreateFromSpecWithInvalidFieldSpec(t *testing.T) {
@@ -55,7 +54,7 @@ func TestCreateFromSpecWithInvalidFieldSpec(t *testing.T) {
 		},
 	}
 	_, err := event.CreateFromSpec(spec)
-	assert.True(t, errors.Is(err, event.ErrCantSetField))
-	assert.Contains(t, err.Error(),
+	assert.Check(t, errors.Is(err, event.ErrCantSetField))
+	assert.ErrorContains(t, err,
 		"\"person.name.first\" path in conflict with value \"Chris Suszynski\"")
 }

--- a/pkg/event/sender_test.go
+++ b/pkg/event/sender_test.go
@@ -2,13 +2,14 @@ package event_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"gotest.tools/v3/assert"
 	"knative.dev/kn-plugin-event/pkg/event"
 )
 
@@ -56,7 +57,8 @@ func passingCase() testCase {
 	return testCase{
 		bufTest: func(t *testing.T) {
 			t.Helper()
-			assert.Contains(t, buf.String(), "Event (ID: 123456) have been sent.")
+			text := buf.String()
+			assert.Check(t, strings.Contains(text, "Event (ID: 123456) have been sent."))
 		},
 		name:         "passing",
 		ce:           ce,

--- a/pkg/sender/in_cluster_test.go
+++ b/pkg/sender/in_cluster_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/kn-plugin-event/pkg/event"
@@ -48,7 +48,7 @@ func TestInClusterSenderSend(t *testing.T) {
 				Type:           event.TargetTypeAddressable,
 				AddressableVal: tt.fields.addressable,
 			})
-			assert.NoError(t, err)
+			assert.NilError(t, err)
 			if err := s.Send(tt.args.ce); !errors.Is(err, tt.err) {
 				t.Errorf("Send() error = %v, wantErr = %v", err, tt.err)
 			}
@@ -155,7 +155,7 @@ func stubAddressResolver() *ar {
 func uri(t *testing.T, uri string) *apis.URL {
 	t.Helper()
 	u, err := apis.ParseURL(uri)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	return u
 }
 
@@ -166,7 +166,7 @@ func exampleEvent(t *testing.T) cloudevents.Event {
 	e.SetType("testing")
 	e.SetSource("source")
 	e.SetTime(time.Unix(1_615_678_145, 0))
-	assert.NoError(t, e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
+	assert.NilError(t, e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
 		"person": map[string]interface{}{
 			"name":  "Chris",
 			"email": "ksuszyns@example.com",

--- a/pkg/tests/delta.go
+++ b/pkg/tests/delta.go
@@ -1,5 +1,19 @@
 package tests
 
-// UnixNanoDelta is used to compare UnixNano dates that should be close enough
+import (
+	"time"
+)
+
+// unixNanoDelta is used to compare UnixNano dates that should be close enough
 // to each other to count as single event.
-const UnixNanoDelta = 50_000_000.
+const unixNanoDelta = 50_000_000.
+
+// TimesAlmostEqual returns true if both times are almost equal.
+func TimesAlmostEqual(at, bt time.Time) bool {
+	af, bf := float64(at.UnixNano()), float64(bt.UnixNano())
+	dt := af - bf
+	if dt < -unixNanoDelta || dt > unixNanoDelta {
+		return false
+	}
+	return true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -356,7 +356,6 @@ github.com/spf13/viper/internal/encoding/json
 github.com/spf13/viper/internal/encoding/toml
 github.com/spf13/viper/internal/encoding/yaml
 # github.com/stretchr/testify v1.7.0
-## explicit
 github.com/stretchr/testify/assert
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv


### PR DESCRIPTION
# Changes

- :broom: Replacing github.com/stretchr/testify with gotest.tools/v3

/kind cleanup

Fixes #91 
