### PR TITLE
Allow to override the test image resolver, to use env variables.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-containerregistry v0.8.1-0.20220120151853-ac864e57b117
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/magefile/mage v1.11.0

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,6 +28,6 @@ set -Eeuo pipefail
 
 ./mage publish
 
-go_test_e2e ./test/...
+go_test_e2e -timeout 10m ./test/... || fail_test 'kn-event e2e tests'
 
 success

--- a/test/e2e/ics_send_test.go
+++ b/test/e2e/ics_send_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestInClusterSender(t *testing.T) {
 	test.MaybeSkip(t)
-	e2e.RegisterPackages()
+	e2e.ConfigureImages(t)
 
 	t.Parallel()
 

--- a/test/e2e/images.go
+++ b/test/e2e/images.go
@@ -1,0 +1,18 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"knative.dev/kn-plugin-event/test/images"
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// ConfigureImages will register packages to be built into test images.
+func ConfigureImages(t images.TestingT) {
+	environment.RegisterPackage(watholaForwarderPackage)
+	images.ResolveImages(t, []string{
+		"knative.dev/reconciler-test/cmd/eventshub",
+		watholaForwarderPackage,
+	})
+}

--- a/test/e2e/kn_service.go
+++ b/test/e2e/kn_service.go
@@ -29,11 +29,6 @@ import (
 
 const watholaForwarderPackage = "knative.dev/eventing/test/test_images/wathola-forwarder"
 
-// RegisterPackages will register packages to be built into test images.
-func RegisterPackages() {
-	environment.RegisterPackage(watholaForwarderPackage)
-}
-
 // SendEventToKnService returns a feature.Feature that verifies the kn-event
 // can send to Knative service.
 func SendEventToKnService() *feature.Feature {

--- a/test/images/envbased.go
+++ b/test/images/envbased.go
@@ -1,0 +1,66 @@
+package images
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+var (
+	// ErrNotFound is returned when there is no environment variable set for
+	// given KO path.
+	ErrNotFound     = errors.New("expected environment variable not found")
+	nonAlphaNumeric = regexp.MustCompile("[^A-Z0-9]+")
+)
+
+// EnvironmentalBasedResolver will try to resolve the images from prefixed
+// environment variables.
+type EnvironmentalBasedResolver struct {
+	Prefix string
+}
+
+func (c *EnvironmentalBasedResolver) Applicable() bool {
+	prefix := c.normalizedPrefix()
+	for _, environment := range os.Environ() {
+		const equalitySignParts = 2
+		parts := strings.SplitN(environment, "=", equalitySignParts)
+		key := parts[0]
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *EnvironmentalBasedResolver) Resolve(kopath string) (name.Reference, error) {
+	prefix := c.normalizedPrefix()
+	shortName := normalize(path.Base(kopath))
+	key := fmt.Sprintf("%s_%s", prefix, shortName)
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return nil, fmt.Errorf("%w: '%s' - kopath: %s", ErrNotFound, key, kopath)
+	}
+	ref, err := name.ParseReference(val)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNotFound, err)
+	}
+	return ref, nil
+}
+
+func (c *EnvironmentalBasedResolver) normalizedPrefix() string {
+	return normalize(c.Prefix)
+}
+
+func normalize(in string) string {
+	return strings.Trim(
+		nonAlphaNumeric.ReplaceAllString(strings.ToUpper(in), "_"),
+		"_",
+	)
+}
+
+var _ Resolver = &EnvironmentalBasedResolver{}

--- a/test/images/register.go
+++ b/test/images/register.go
@@ -1,0 +1,5 @@
+package images
+
+// Resolvers an array of resolvers to which resolvers could be added for
+// downstream projects.
+var Resolvers = make([]Resolver, 0, 1) //nolint:gochecknoglobals

--- a/test/images/resolver.go
+++ b/test/images/resolver.go
@@ -1,0 +1,56 @@
+package images
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"k8s.io/apimachinery/pkg/util/json"
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// Resolver will resolve given KO package paths into real OCI images references.
+// This interface probably should be moved into reconciler-test framework. See:
+// https://github.com/knative-sandbox/reconciler-test/issues/303
+type Resolver interface {
+	// Resolve will resolve given KO package path into real OCI image reference.
+	Resolve(kopath string) (name.Reference, error)
+	// Applicable will tell that given resolver is applicable to current runtime
+	// environment, or not.
+	Applicable() bool
+}
+
+// TestingT a subset of testing.T.
+type TestingT interface {
+	Logf(fmt string, args ...interface{})
+	Fatal(args ...interface{})
+	Fatalf(fmt string, args ...interface{})
+}
+
+// ResolveImages will try to resolve the images, using given resolver(s).
+func ResolveImages(t TestingT, packages []string) {
+	for _, resolver := range Resolvers {
+		if resolver.Applicable() {
+			resolveImagesWithResolver(t, packages, resolver)
+			return
+		}
+	}
+	if len(Resolvers) > 0 {
+		t.Fatalf("Couldn't resolve images with registered resolvers: %+q", Resolvers)
+	}
+}
+
+func resolveImagesWithResolver(t TestingT, packages []string, resolver Resolver) {
+	resolved := make(map[string]string)
+	for _, pack := range packages {
+		kopath := "ko://" + pack
+		image, err := resolver.Resolve(kopath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolved[kopath] = image.String()
+	}
+	repr, err := json.Marshal(resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Images resolved to: %s", string(repr))
+	environment.WithImages(resolved)
+}

--- a/test/pkg/clients.go
+++ b/test/pkg/clients.go
@@ -49,6 +49,11 @@ func WithKnTest(tb testing.TB, handler func(c *TestContext)) {
 	it, err := clienttest.NewKnTest()
 	assert.NilError(tb, err)
 	tb.Cleanup(func() {
+		if tb.Failed() {
+			tb.Logf("Skipping '%s' namespace teardown because '%s' test is failing",
+				it.Namespace(), tb.Name())
+			return
+		}
 		assert.NilError(tb, it.Teardown())
 	})
 	handler(&TestContext{

--- a/vendor/gotest.tools/v3/poll/check.go
+++ b/vendor/gotest.tools/v3/poll/check.go
@@ -1,0 +1,39 @@
+package poll
+
+import (
+	"net"
+	"os"
+)
+
+// Check is a function which will be used as check for the WaitOn method.
+type Check func(t LogT) Result
+
+// FileExists looks on filesystem and check that path exists.
+func FileExists(path string) Check {
+	return func(t LogT) Result {
+		_, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Logf("waiting on file %s to exist", path)
+			return Continue("file %s does not exist", path)
+		}
+		if err != nil {
+			return Error(err)
+		}
+
+		return Success()
+	}
+}
+
+// Connection try to open a connection to the address on the
+// named network. See net.Dial for a description of the network and
+// address parameters.
+func Connection(network, address string) Check {
+	return func(t LogT) Result {
+		_, err := net.Dial(network, address)
+		if err != nil {
+			t.Logf("waiting on socket %s://%s to be available...", network, address)
+			return Continue("socket %s://%s not available", network, address)
+		}
+		return Success()
+	}
+}

--- a/vendor/gotest.tools/v3/poll/poll.go
+++ b/vendor/gotest.tools/v3/poll/poll.go
@@ -1,0 +1,171 @@
+/*Package poll provides tools for testing asynchronous code.
+ */
+package poll // import "gotest.tools/v3/poll"
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/assert"
+)
+
+// TestingT is the subset of testing.T used by WaitOn
+type TestingT interface {
+	LogT
+	Fatalf(format string, args ...interface{})
+}
+
+// LogT is a logging interface that is passed to the WaitOn check function
+type LogT interface {
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+}
+
+type helperT interface {
+	Helper()
+}
+
+// Settings are used to configure the behaviour of WaitOn
+type Settings struct {
+	// Timeout is the maximum time to wait for the condition. Defaults to 10s.
+	Timeout time.Duration
+	// Delay is the time to sleep between checking the condition. Defaults to
+	// 100ms.
+	Delay time.Duration
+}
+
+func defaultConfig() *Settings {
+	return &Settings{Timeout: 10 * time.Second, Delay: 100 * time.Millisecond}
+}
+
+// SettingOp is a function which accepts and modifies Settings
+type SettingOp func(config *Settings)
+
+// WithDelay sets the delay to wait between polls
+func WithDelay(delay time.Duration) SettingOp {
+	return func(config *Settings) {
+		config.Delay = delay
+	}
+}
+
+// WithTimeout sets the timeout
+func WithTimeout(timeout time.Duration) SettingOp {
+	return func(config *Settings) {
+		config.Timeout = timeout
+	}
+}
+
+// Result of a check performed by WaitOn
+type Result interface {
+	// Error indicates that the check failed and polling should stop, and the
+	// the has failed
+	Error() error
+	// Done indicates that polling should stop, and the test should proceed
+	Done() bool
+	// Message provides the most recent state when polling has not completed
+	Message() string
+}
+
+type result struct {
+	done    bool
+	message string
+	err     error
+}
+
+func (r result) Done() bool {
+	return r.done
+}
+
+func (r result) Message() string {
+	return r.message
+}
+
+func (r result) Error() error {
+	return r.err
+}
+
+// Continue returns a Result that indicates to WaitOn that it should continue
+// polling. The message text will be used as the failure message if the timeout
+// is reached.
+func Continue(message string, args ...interface{}) Result {
+	return result{message: fmt.Sprintf(message, args...)}
+}
+
+// Success returns a Result where Done() returns true, which indicates to WaitOn
+// that it should stop polling and exit without an error.
+func Success() Result {
+	return result{done: true}
+}
+
+// Error returns a Result that indicates to WaitOn that it should fail the test
+// and stop polling.
+func Error(err error) Result {
+	return result{err: err}
+}
+
+// WaitOn a condition or until a timeout. Poll by calling check and exit when
+// check returns a done Result. To fail a test and exit polling with an error
+// return a error result.
+func WaitOn(t TestingT, check Check, pollOps ...SettingOp) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	config := defaultConfig()
+	for _, pollOp := range pollOps {
+		pollOp(config)
+	}
+
+	var lastMessage string
+	after := time.After(config.Timeout)
+	chResult := make(chan Result)
+	for {
+		go func() {
+			chResult <- check(t)
+		}()
+		select {
+		case <-after:
+			if lastMessage == "" {
+				lastMessage = "first check never completed"
+			}
+			t.Fatalf("timeout hit after %s: %s", config.Timeout, lastMessage)
+		case result := <-chResult:
+			switch {
+			case result.Error() != nil:
+				t.Fatalf("polling check failed: %s", result.Error())
+			case result.Done():
+				return
+			}
+			time.Sleep(config.Delay)
+			lastMessage = result.Message()
+		}
+	}
+}
+
+// Compare values using the cmp.Comparison. If the comparison fails return a
+// result which indicates to WaitOn that it should continue waiting.
+// If the comparison is successful then WaitOn stops polling.
+func Compare(compare cmp.Comparison) Result {
+	buf := new(logBuffer)
+	if assert.RunComparison(buf, assert.ArgsAtZeroIndex, compare) {
+		return Success()
+	}
+	return Continue(buf.String())
+}
+
+type logBuffer struct {
+	log [][]interface{}
+}
+
+func (c *logBuffer) Log(args ...interface{}) {
+	c.log = append(c.log, args)
+}
+
+func (c *logBuffer) String() string {
+	b := new(strings.Builder)
+	for _, item := range c.log {
+		b.WriteString(fmt.Sprint(item...) + " ")
+	}
+	return b.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,6 +179,7 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-containerregistry v0.8.1-0.20220120151853-ac864e57b117
+## explicit
 github.com/google/go-containerregistry/cmd/crane/cmd
 github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/estargz
@@ -645,6 +646,7 @@ gotest.tools/v3/internal/assert
 gotest.tools/v3/internal/difflib
 gotest.tools/v3/internal/format
 gotest.tools/v3/internal/source
+gotest.tools/v3/poll
 # k8s.io/api v0.22.5
 ## explicit
 k8s.io/api/admissionregistration/v1


### PR DESCRIPTION
Also, fixing test of `test/pkg/k8s.TestResolveAddress` which behaved flaky on downstream projects.

# Changes


- :gift: Allow to override the test image resolver, to use env variables.
- :bug: Fixing flaky test of `test/pkg/k8s.TestResolveAddress`.

/kind enhancement

Fixes #166
Fixes #167