### PR TITLE
:bug: Align artifact.list location

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,10 +21,12 @@ ORG_NAME="${ORG_NAME:-knative-sandbox}"
 
 source "$(dirname "$0")/../vendor/knative.dev/hack/release.sh"
 
+export ARTIFACTS_LIST="${ARTIFACTS_LIST:-${ARTIFACTS}/artifacts.list}"
+
 function build_release {
   export ARTIFACTS_TO_PUBLISH
   ./mage clean publish
-  ARTIFACTS_TO_PUBLISH="$(tr '\r\n' ' ' < build/_output/artifacts.list)"
+  ARTIFACTS_TO_PUBLISH="$(tr '\r\n' ' ' < "${ARTIFACTS_LIST}")"
   # TODO: Remove digest calculation once resolved
   #       https://github.com/wavesoftware/go-magetasks/issues/18
   calculate_checksums
@@ -38,7 +40,7 @@ function calculate_checksums {
     pushd "$(dirname "$file")" >/dev/null
     sha256sum "$(basename "$file")" >> "${checksums}"
     popd >/dev/null
-  done < build/_output/artifacts.list
+  done < "${ARTIFACTS_LIST}"
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} ${checksums}"
 }
 


### PR DESCRIPTION
# Changes

- :bug: Align artifact.list location

This is caused by: https://github.com/wavesoftware/go-magetasks/blame/685c1062a6dd0789454d964da18946aa3669b026/pkg/files/dirs.go#L23-L26


/kind bug

Fixes the failing release: https://prow.knative.dev/view/gs/knative-prow/logs/release_kn-plugin-event_main_periodic/1582667866417664000