### PR TITLE
:bug: RFC 1123 valid sender job name

### DIFF
--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -20,10 +20,11 @@ type App struct {
 
 func (a *App) Command() *cobra.Command {
 	c := &cobra.Command{
-		Use:     metadata.PluginUse,
-		Aliases: []string{fmt.Sprintf("kn %s", metadata.PluginUse)},
-		Short:   metadata.PluginDescription,
-		Long:    metadata.PluginLongDescription,
+		Use:          metadata.PluginUse,
+		Aliases:      []string{fmt.Sprintf("kn %s", metadata.PluginUse)},
+		Short:        metadata.PluginDescription,
+		Long:         metadata.PluginLongDescription,
+		SilenceUsage: true,
 	}
 	c.PersistentFlags().BoolVarP(
 		&a.Verbose, "verbose", "v",

--- a/pkg/sender/in_cluster_test.go
+++ b/pkg/sender/in_cluster_test.go
@@ -9,9 +9,13 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"knative.dev/kn-plugin-event/pkg/cli/ics"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/k8s"
 	"knative.dev/kn-plugin-event/pkg/sender"
@@ -20,12 +24,15 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
+const toLongForRFC1123 = 64
+
 var errExampleValidationFault = errors.New("example validation fault")
 
 func TestInClusterSenderSend(t *testing.T) {
 	testCases := []inClusterTestCase{
 		passingInClusterSenderSend(t),
 		couldResolveAddress(t),
+		idViolatesRFC1123(t),
 	}
 	for i := range testCases {
 		tt := testCases[i]
@@ -49,7 +56,7 @@ func TestInClusterSenderSend(t *testing.T) {
 				AddressableVal: tt.fields.addressable,
 			})
 			assert.NilError(t, err)
-			if err := s.Send(tt.args.ce); !errors.Is(err, tt.err) {
+			if err = s.Send(tt.args.ce); !errors.Is(err, tt.err) {
 				t.Errorf("Send() error = %v, wantErr = %v", err, tt.err)
 			}
 		})
@@ -86,15 +93,15 @@ func passingInClusterSenderSend(t *testing.T) inClusterTestCase {
 
 func couldResolveAddress(t *testing.T) inClusterTestCase {
 	t.Helper()
-	ar := stubAddressResolver()
-	ar.isValid = func(ref *tracker.Reference) error {
+	sar := stubAddressResolver()
+	sar.isValid = func(ref *tracker.Reference) error {
 		return errExampleValidationFault
 	}
 	return inClusterTestCase{
 		name: "couldResolveAddress",
 		fields: fields{
 			addressable:     exampleBrokerAddressableSpec(t),
-			addressResolver: ar,
+			addressResolver: sar,
 			jobRunner: stubJobRunner(func(job *batchv1.Job) bool {
 				return true
 			}),
@@ -106,6 +113,39 @@ func couldResolveAddress(t *testing.T) inClusterTestCase {
 	}
 }
 
+func idViolatesRFC1123(t *testing.T) inClusterTestCase {
+	t.Helper()
+	ce := cetest.FullEvent()
+	ce.SetID(newIDViolatesRFC1123())
+	return inClusterTestCase{
+		name: "idViolatesRFC1123",
+		fields: fields{
+			addressable:     exampleBrokerAddressableSpec(t),
+			addressResolver: stubAddressResolver(),
+			jobRunner: fnJobRunner(func(job *batchv1.Job) error {
+				name := job.GetName()
+				errs := validation.IsDNS1123Subdomain(name)
+				if len(errs) > 0 {
+					//goland:noinspection GoErrorStringFormat
+					return fmt.Errorf("Job.batch \"%s\" is invalid: "+ //nolint:goerr113
+						"metadata.name: Invalid value: \"%s\": %s",
+						name, name, strings.Join(errs, ", "))
+				}
+				return nil
+			}),
+		},
+		args: args{
+			ce: ce,
+		},
+		err: ics.ErrCantSendWithICS,
+	}
+}
+
+// newIDViolatesRFC1123 returns a new random ID which violates the RFC 1123 on purpose.
+func newIDViolatesRFC1123() string {
+	return "test-event-" + strings.ToUpper(rand.String(toLongForRFC1123))
+}
+
 func envof(envs []corev1.EnvVar, name string) (string, bool) {
 	for _, env := range envs {
 		if env.Name == name {
@@ -115,22 +155,17 @@ func envof(envs []corev1.EnvVar, name string) (string, bool) {
 	return "", false
 }
 
-type jr struct {
-	isValid func(job *batchv1.Job) bool
-}
+type fnJobRunner func(job *batchv1.Job) error
 
-func (j *jr) Run(job *batchv1.Job) error {
-	if !j.isValid(job) {
-		return event.ErrCantSentEvent
-	}
-	return nil
+func (f fnJobRunner) Run(job *batchv1.Job) error {
+	return f(job)
 }
 
 type ar struct {
 	isValid func(ref *tracker.Reference) error
 }
 
-func (a *ar) ResolveAddress(ref *tracker.Reference, uri *apis.URL) (*url.URL, error) {
+func (a *ar) ResolveAddress(ref *tracker.Reference, _ *apis.URL) (*url.URL, error) {
 	if a.isValid != nil {
 		if err := a.isValid(ref); err != nil {
 			return nil, err
@@ -144,8 +179,13 @@ func (a *ar) ResolveAddress(ref *tracker.Reference, uri *apis.URL) (*url.URL, er
 	return u, nil
 }
 
-func stubJobRunner(isValid func(job *batchv1.Job) bool) *jr {
-	return &jr{isValid: isValid}
+func stubJobRunner(isValid func(job *batchv1.Job) bool) k8s.JobRunner {
+	return fnJobRunner(func(job *batchv1.Job) error {
+		if !isValid(job) {
+			return event.ErrCantSentEvent
+		}
+		return nil
+	})
 }
 
 func stubAddressResolver() *ar {

--- a/pkg/sender/in_cluster_test.go
+++ b/pkg/sender/in_cluster_test.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"knative.dev/kn-plugin-event/pkg/cli/ics"
 	"knative.dev/kn-plugin-event/pkg/event"
 	"knative.dev/kn-plugin-event/pkg/k8s"
 	"knative.dev/kn-plugin-event/pkg/sender"
@@ -124,7 +123,7 @@ func idViolatesRFC1123(t *testing.T) inClusterTestCase {
 			addressResolver: stubAddressResolver(),
 			jobRunner: fnJobRunner(func(job *batchv1.Job) error {
 				name := job.GetName()
-				errs := validation.IsDNS1123Subdomain(name)
+				errs := validation.IsDNS1035Label(name)
 				if len(errs) > 0 {
 					//goland:noinspection GoErrorStringFormat
 					return fmt.Errorf("Job.batch \"%s\" is invalid: "+ //nolint:goerr113
@@ -137,7 +136,6 @@ func idViolatesRFC1123(t *testing.T) inClusterTestCase {
 		args: args{
 			ce: ce,
 		},
-		err: ics.ErrCantSendWithICS,
 	}
 }
 

--- a/test/e2e/ics_send.go
+++ b/test/e2e/ics_send.go
@@ -100,6 +100,9 @@ func handleSendErr(ctx context.Context, t feature.T, err error, ev cloudevents.E
 	if kerr != nil {
 		log.Error(kerr)
 	}
+	if len(jlist.Items) != 1 {
+		t.Fatal(err)
+	}
 	jobName := jlist.Items[0].Name
 	plist, kerr := pods.List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("job-name=%s", jobName),

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -758,6 +758,7 @@ k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
# Changes

- :bug: RFC 1123 valid sender job name

/kind bug

Fixes #223 


**Release Note**

```release-note
:bug: Sending an event with ID validating RFC 1123 using in-cluster sender no longer results in failure
:bug: Error will no longer display usage
```