### PR TITLE
:bug: Delete successful job with background propagation policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.0
+	github.com/stretchr/testify v1.8.0
 	github.com/thediveo/enumflag v0.10.0
 	github.com/wavesoftware/go-commandline v1.0.0
 	github.com/wavesoftware/go-ensure v1.0.0
@@ -114,7 +115,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/wavesoftware/go-retcode v1.0.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect

--- a/pkg/k8s/jobrunner.go
+++ b/pkg/k8s/jobrunner.go
@@ -96,7 +96,10 @@ func waitAndClose(tsk task) {
 func (j *jobRunner) deleteJob(job *batchv1.Job) error {
 	ctx := j.kube.Context()
 	jobs := j.kube.Typed().BatchV1().Jobs(job.GetNamespace())
-	err := jobs.Delete(ctx, job.GetName(), metav1.DeleteOptions{})
+	policy := metav1.DeletePropagationBackground
+	err := jobs.Delete(ctx, job.GetName(), metav1.DeleteOptions{
+		PropagationPolicy: &policy,
+	})
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrICSenderJobFailed, err)
 	}

--- a/test/e2e/ics_send.go
+++ b/test/e2e/ics_send.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package e2e
 
@@ -10,6 +9,7 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/icmd"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/kn-plugin-event/test"
@@ -17,9 +17,15 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
-	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	eventshubassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	issue228Warn = "child pods are preserved by default when jobs are deleted; " +
+		"set propagationPolicy=Background to remove them or set " +
+		"propagationPolicy=Orphan to suppress this warning"
 )
 
 // SendEventFeature will create a feature.Feature that will test sending an
@@ -71,12 +77,13 @@ func sendEvent(ev cloudevents.Event, sink Sink) feature.StepFn {
 		}); err != nil {
 			handleSendErr(ctx, t, err, ev)
 		}
+		assert.NotContains(t, result.Stderr(), issue228Warn)
 		log.Info("Succeeded")
 	}
 }
 
 func receiveEvent(ev cloudevents.Event, sinkName string) feature.StepFn {
-	return assert.OnStore(sinkName).
+	return eventshubassert.OnStore(sinkName).
 		MatchEvent(cetest.HasId(ev.ID())).
 		Exact(1)
 }


### PR DESCRIPTION
# Changes

- :bug: Delete successful job with background propagation policy

/kind bug

Fixes #228 

**Release Note**

```release-note
:bug: Sending event using in-cluster sender no longer display a Warn about propagation policy
```