### PR TITLE
:broom: Reset root module mock version to v0.0.0

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/wavesoftware/go-magetasks v0.8.1
-	knative.dev/kn-plugin-event v0.34.1-0.20230130203928-59adc6bd3cf7
+	knative.dev/kn-plugin-event v0.0.0
 )
 
 require (

--- a/build/vendor/modules.txt
+++ b/build/vendor/modules.txt
@@ -729,7 +729,7 @@ k8s.io/klog/v2/internal/severity
 k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/strings/slices
-# knative.dev/kn-plugin-event v0.34.1-0.20230130203928-59adc6bd3cf7 => ../
+# knative.dev/kn-plugin-event v0.0.0 => ../
 ## explicit; go 1.18
 knative.dev/kn-plugin-event/pkg/metadata
 # sigs.k8s.io/kind v0.14.0


### PR DESCRIPTION
# Changes

- :broom: Reset root module mock version to v0.0.0

/kind cleanup

Related https://github.com/knative/hack/issues/264
