### PR TITLE
[release-1.9] :bug: Bumping knative.dev/hack to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,8 @@ require (
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 	knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526
-	knative.dev/eventing v0.36.1
-	knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
+	knative.dev/eventing v0.36.4
+	knative.dev/hack v0.0.0-20230210215449-d71d569c4308
 	knative.dev/pkg v0.0.0-20230117181655-247510c00e9d
 	knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644
 	knative.dev/serving v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1158,10 +1158,10 @@ k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJ
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526 h1:/3bTP61VARRn34cQ5e3P1KwRGxvuSsZmknt3akFpNvg=
 knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526/go.mod h1:dpY2cjKD/xjGjLQf/esJ1jMYko0iuV15PqYOL+uCEXc=
-knative.dev/eventing v0.36.1 h1:QHLVpO8i7JWg0a3rSDjbH8WZk6YlPY2g5mPvWovh5aI=
-knative.dev/eventing v0.36.1/go.mod h1:Qka5Z6+LeMoHGL1QAznVdmq5LAu21b4F3rgxc2AMgRg=
-knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9 h1:CDa7s9KspEZqPhk7cN68ZypRLuAvSgr+knoOaXSsrHk=
-knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
+knative.dev/eventing v0.36.4 h1:B9WAf1qFXP815RAEwLsBH3P5GpWJiwdVYGzlOBi/bKA=
+knative.dev/eventing v0.36.4/go.mod h1:Qka5Z6+LeMoHGL1QAznVdmq5LAu21b4F3rgxc2AMgRg=
+knative.dev/hack v0.0.0-20230210215449-d71d569c4308 h1:zH5OedRfo9SB22o25VNQ+vygceTvOujsnLYaALb8jos=
+knative.dev/hack v0.0.0-20230210215449-d71d569c4308/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/networking v0.0.0-20230123233838-db2bcbea2560 h1:iprdS5tKTXtgV9dGryuwJJJTTdl5LusCHOelKdezR3I=
 knative.dev/networking v0.0.0-20230123233838-db2bcbea2560/go.mod h1:rn1yRurhkxmSFkpqs/YdG7b9DiYj0VlmLFzBdOQjpOo=
 knative.dev/pkg v0.0.0-20230117181655-247510c00e9d h1:pjKDcvHoMib8nRp56eISRmMj/pFMzJljnzvMvGCIReI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1066,7 +1066,7 @@ knative.dev/client-pkg/pkg/util
 knative.dev/client-pkg/pkg/util/mock
 knative.dev/client-pkg/pkg/util/test
 knative.dev/client-pkg/pkg/wait
-# knative.dev/eventing v0.36.1
+# knative.dev/eventing v0.36.4
 ## explicit; go 1.18
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1105,7 +1105,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/config
 knative.dev/eventing/test/upgrade/prober/wathola/event
 knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/sender
-# knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
+# knative.dev/hack v0.0.0-20230210215449-d71d569c4308
 ## explicit; go 1.18
 knative.dev/hack
 # knative.dev/networking v0.0.0-20230123233838-db2bcbea2560


### PR DESCRIPTION
# Changes

- [release-1.9] :bug: Bumping knative.dev/hack to latest main
  - In this PR I've manually bumped the knative.dev/hack to main, before cherry-picking the https://github.com/knative/hack/pull/268 to `release-1.9`, so that regular update-deps will consume it.


/kind bug

Fixes https://github.com/knative-sandbox/homebrew-kn-plugins/issues/134

**Release Note**

```release-note
Fixing the invalid checksums on MacOS platform, for release-1.9, making homebrew install work again.
```