### PR TITLE
Fix broken checksums generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/client-go v0.25.4
 	knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526
 	knative.dev/eventing v0.36.1
-	knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
+	knative.dev/hack v0.0.0-20230210215449-d71d569c4308
 	knative.dev/pkg v0.0.0-20230117181655-247510c00e9d
 	knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644
 	knative.dev/serving v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1160,8 +1160,8 @@ knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526 h1:/3bTP61VARRn34cQ5e3
 knative.dev/client-pkg v0.0.0-20230120062501-d4ab4e492526/go.mod h1:dpY2cjKD/xjGjLQf/esJ1jMYko0iuV15PqYOL+uCEXc=
 knative.dev/eventing v0.36.1 h1:QHLVpO8i7JWg0a3rSDjbH8WZk6YlPY2g5mPvWovh5aI=
 knative.dev/eventing v0.36.1/go.mod h1:Qka5Z6+LeMoHGL1QAznVdmq5LAu21b4F3rgxc2AMgRg=
-knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9 h1:CDa7s9KspEZqPhk7cN68ZypRLuAvSgr+knoOaXSsrHk=
-knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
+knative.dev/hack v0.0.0-20230210215449-d71d569c4308 h1:zH5OedRfo9SB22o25VNQ+vygceTvOujsnLYaALb8jos=
+knative.dev/hack v0.0.0-20230210215449-d71d569c4308/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/networking v0.0.0-20230123233838-db2bcbea2560 h1:iprdS5tKTXtgV9dGryuwJJJTTdl5LusCHOelKdezR3I=
 knative.dev/networking v0.0.0-20230123233838-db2bcbea2560/go.mod h1:rn1yRurhkxmSFkpqs/YdG7b9DiYj0VlmLFzBdOQjpOo=
 knative.dev/pkg v0.0.0-20230117181655-247510c00e9d h1:pjKDcvHoMib8nRp56eISRmMj/pFMzJljnzvMvGCIReI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1105,7 +1105,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/config
 knative.dev/eventing/test/upgrade/prober/wathola/event
 knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/sender
-# knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
+# knative.dev/hack v0.0.0-20230210215449-d71d569c4308
 ## explicit; go 1.18
 knative.dev/hack
 # knative.dev/networking v0.0.0-20230123233838-db2bcbea2560


### PR DESCRIPTION
/cc @cardil 

Lets merge this, run the nightly then download the files and check before cutting a release.

```
gsutil cp -r gs://knative-nightly/kn-plugin-event/latest .
cd latest && sha256sum --check --ignore-missing checksums.txt
```