### PR TITLE
bump linter v2.5.0 -> v2.11.4 + fixes

### DIFF
--- a/build/Magefile.go
+++ b/build/Magefile.go
@@ -60,7 +60,7 @@ func init() { //nolint:gochecknoinits
 		},
 		Artifacts: []config.Artifact{sender, cli},
 		Checks: []config.Task{checks.GolangCiLint(func(o *checks.GolangCiLintOptions) {
-			o.Version = "v2.5.0"
+			o.Version = "v2.11.4"
 		})},
 		BuildVariables: map[string]config.Resolver{
 			metadata.ImageBasenamePath(): imageBasenameFromEnv,

--- a/test/e2e/ics_send.go
+++ b/test/e2e/ics_send.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
@@ -67,7 +67,7 @@ func sendEvent(ev cloudevents.Event, sink Sink) feature.StepFn {
 		if artifacts == "" {
 			artifacts = os.TempDir()
 		}
-		cacheDir := path.Join(artifacts, t.Name())
+		cacheDir := filepath.Clean(filepath.Join(artifacts, t.Name()))
 		if err := os.MkdirAll(cacheDir, dirPerm); err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +80,7 @@ func sendEvent(ev cloudevents.Event, sink Sink) feature.StepFn {
 			Err:      fmt.Sprintf("Event (ID: %s) have been sent.", ev.ID()),
 		}); err != nil {
 			t.Fatal(err, "\n\nExecution log: "+
-				path.Join(cacheDir, "last-exec.log.jsonl"))
+				filepath.Join(cacheDir, "last-exec.log.jsonl"))
 		}
 		assert.NotContains(t, result.Stderr(), issue228Warn)
 		log.Info("Succeeded")


### PR DESCRIPTION
fixes the CI for release
- bump linter in `build/Magefile.go` to run with go 1.26
- subsequently fix an error because of a newly introduced linter rule with the newer version 